### PR TITLE
feat: support multiple PLC variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # S7 Logging and Graphing
 
-This project provides a simple Python GUI tool for connecting to a Siemens S7 PLC using the `snap7` library.  It polls a data block value, plots the readings live and can export the collected data to an Excel file.
+This project provides a simple Python GUI tool for connecting to a Siemens S7 PLC using the `snap7` library.  It polls data block values, plots the readings live and can export the collected data to an Excel file. Logged values are also written to a temporary file so logging can continue after a crash.
 
 ## Features
 - Connect to a PLC by entering IP, rack and slot
+- Log multiple addresses simultaneously; use **+** and **-** to add or remove variables
 - Read from any data block and address with selectable data type (BOOL, INT, DINT or REAL)
-- Poll at a custom interval and display live values on a matplotlib graph
+- Poll at a custom interval and display live values on a matplotlib graph with a legend showing each address
 - Choose between line and scatter plots
 - Export all collected values to an Excel (`.xlsx`) file
+- Clear logged data via the **Clear** button (with confirmation) which also removes the temporary log file
 
 ## Requirements
 Install dependencies:
@@ -23,7 +25,7 @@ python plc_logger_gui.py
 ```
 
 1. Enter the PLC connection parameters and data block details.
-2. Click **Connect** to establish the connection.
+2. Add or remove addresses using **+** and **-** then click **Connect** to establish the connection.
 3. Choose the polling interval and graph type then press **Start** to begin logging.
-4. Click **Export** to save the collected data to an Excel file.
+4. Use **Clear** to reset all data or **Export** to save the collected data to an Excel file.
 


### PR DESCRIPTION
## Summary
- allow adding/removing PLC addresses dynamically
- persist logged data in a temp file to resume after crashes
- add clear action with confirmation and legend for plotted addresses

## Testing
- `python -m py_compile plc_logger_gui.py`
- `python - <<'PY'
import plc_logger_gui
print('imported ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac09d0fb68832f8a2cb10c967a7b9e