### PR TITLE
Add stop/resume logging controls and improve Excel export

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This project provides a simple Python GUI tool for connecting to a Siemens S7 PL
 - Connect to a PLC by entering IP, rack and slot
 - Log multiple addresses simultaneously; use **+** and **-** to add or remove variables
 - Read from any data block and address with selectable data type (BOOL, INT, DINT or REAL)
-- Poll at a custom interval and display live values on a matplotlib graph with a legend showing each address
+- Poll at a custom interval and display live values on a matplotlib graph with a legend showing each address and its last value
 - Choose between line and scatter plots
+- Start, stop and resume logging via dedicated buttons
 - Export all collected values to an Excel (`.xlsx`) file
 - Clear logged data via the **Clear** button (with confirmation) which also removes the temporary log file
 
@@ -15,7 +16,7 @@ This project provides a simple Python GUI tool for connecting to a Siemens S7 PL
 Install dependencies:
 
 ```bash
-pip install python-snap7 pandas matplotlib
+pip install python-snap7 pandas matplotlib openpyxl
 ```
 
 ## Usage
@@ -26,6 +27,6 @@ python plc_logger_gui.py
 
 1. Enter the PLC connection parameters and data block details.
 2. Add or remove addresses using **+** and **-** then click **Connect** to establish the connection.
-3. Choose the polling interval and graph type then press **Start** to begin logging.
+3. Choose the polling interval and graph type then press **Start** to begin logging. Use **Stop** and **Resume** to control polling.
 4. Use **Clear** to reset all data or **Export** to save the collected data to an Excel file.
 


### PR DESCRIPTION
## Summary
- add start/stop/resume controls to logging UI
- show last value in plot legend and improve Excel export with openpyxl
- update documentation

## Testing
- `python3 -m py_compile plc_logger_gui.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac57564eb4832f8ec244e51b2ad5e2